### PR TITLE
Minimum length increased to avoid reading uninitialised data.

### DIFF
--- a/VescUart.cpp
+++ b/VescUart.cpp
@@ -190,8 +190,8 @@ bool VescUartGetValue(bldcMeasure& values) {
 	PackSendPayload(command, 1);
 	delay(100); //needed, otherwise data is not read
 	int lenPayload = ReceiveUartMessage(payload);
-	if (lenPayload > 0) {
-		bool read = ProcessReadPacket(payload, values, lenPayload); //returns true if sucessfull
+	if (lenPayload > 55) {
+		bool read = ProcessReadPacket(payload, values, lenPayload); //returns true if sucessful
 		return read;
 	}
 	else


### PR DESCRIPTION
Problems encountered when the getValues packet was reflected back down the serial port and was read as a valid value results packet. The easy solution is to ensure that the values packet is at least 55 bytes long as this is the length of all the data it should contain.