### PR TITLE
Fix buffer_get_bool  not incrementing index

### DIFF
--- a/buffer.cpp
+++ b/buffer.cpp
@@ -100,12 +100,12 @@ bool buffer_get_bool(const uint8_t *buffer, int32_t *index) {
 	
 		if (buffer[*index] == 1)
 		{
-			index++;
+			(*index)++;
 			return true;
 		}
 		else
 		{
-			index++;
+			(*index)++;
 			return false;
 		}
 		


### PR DESCRIPTION
The index variable needs to be incremented when calling this function, as it is with other "get_" functions.